### PR TITLE
100% streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ examines three, breaking them into standalone modules:
 * **File ([src/upload-file.ts](./src/upload-file.ts)):** hapi streams each
   uploaded file to the temporary directory, then calls the route handler with
   the temporary files' paths.
-* **Stream ([src/upload-stream.ts](./src/upload-stream.ts)):** hapi parses the
-  form request and transforms uploaded files into streams, then calls the route
-  handler with these streams.
+* **Stream ([src/upload-stream.ts](./src/upload-stream.ts)):** hapi passes the
+  raw request to the route handler, which transforms the multi-part files into
+  streams.
 
 Each file contains extensive commenting explaining how to approach each
 strategy.

--- a/package.json
+++ b/package.json
@@ -3,18 +3,22 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "dependencies": {
+    "@hapi/boom": "^7.4.3",
+    "@hapi/content": "^4.1.0",
     "@hapi/good": "^8.2.1",
     "@hapi/good-console": "^8.1.1",
     "@hapi/good-squeeze": "^5.2.1",
     "@hapi/hapi": "^18.3.2",
     "@hapi/inert": "^5.2.1",
     "@hapi/joi": "^15.1.1",
+    "@hapi/pez": "^4.1.1",
     "@hapi/wreck": "^15.0.2",
     "hard-rejection": "^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/form-data": "^2.5.0",
+    "@types/hapi__boom": "^7.4.1",
     "@types/hapi__hapi": "^18.2.5",
     "@types/hapi__inert": "^5.2.0",
     "@types/hapi__wreck": "^15.0.1",
@@ -28,7 +32,7 @@
     "sinon": "^7.4.1",
     "stream-to-promise": "^2.2.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   },
   "scripts": {
     "build": "tsc",

--- a/types/hapi__content.d.ts
+++ b/types/hapi__content.d.ts
@@ -1,0 +1,14 @@
+declare module '@hapi/content' {
+    export interface ContentType {
+        boundary?: string;
+        mime: string;
+    }
+
+    export interface ContentDisposition {
+        filename: string;
+        name: string;
+    }
+
+    export function disposition(header: string): ContentDisposition;
+    export function type(header: string): ContentType;
+}

--- a/types/hapi__pez.d.ts
+++ b/types/hapi__pez.d.ts
@@ -1,0 +1,16 @@
+declare module '@hapi/pez' {
+    import stream from 'stream';
+
+    export interface DispenserOptions {
+        boundary?: string;
+        maxBytes?: number;
+    }
+
+    export interface DispenserPart extends stream.Readable {
+        name: string;
+    }
+
+    export class Dispenser extends stream.Writable {
+        constructor(options: DispenserOptions);
+    }
+}

--- a/types/hapi__pez.d.ts
+++ b/types/hapi__pez.d.ts
@@ -6,10 +6,6 @@ declare module '@hapi/pez' {
         maxBytes?: number;
     }
 
-    export interface DispenserPart extends stream.Readable {
-        name: string;
-    }
-
     export class Dispenser extends stream.Writable {
         constructor(options: DispenserOptions);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
   dependencies:
     "@hapi/hoek" "8.x.x"
 
-"@hapi/boom@7.x.x":
+"@hapi/boom@7.x.x", "@hapi/boom@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-7.4.3.tgz#79ffed6ef8c625046a3bd069abed5a9d35fc50c1"
   integrity sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==
@@ -75,7 +75,7 @@
     "@hapi/joi" "15.x.x"
     "@hapi/podium" "3.x.x"
 
-"@hapi/content@4.x.x":
+"@hapi/content@4.x.x", "@hapi/content@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/content/-/content-4.1.0.tgz#5265516949ca081e85a43e97c1058ff53fc69714"
   integrity sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==
@@ -215,7 +215,7 @@
   dependencies:
     "@hapi/hoek" "8.x.x"
 
-"@hapi/pez@4.x.x":
+"@hapi/pez@4.x.x", "@hapi/pez@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/pez/-/pez-4.1.1.tgz#d515ed75bc082cb6da3ab8d7804a3b41a4d63be6"
   integrity sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==
@@ -345,7 +345,7 @@
   dependencies:
     form-data "*"
 
-"@types/hapi__boom@*":
+"@types/hapi__boom@*", "@types/hapi__boom@^7.4.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@types/hapi__boom/-/hapi__boom-7.4.1.tgz#06439d7637245dcbe6dd6548d2a91f2c1243d80b"
   integrity sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg==
@@ -1461,7 +1461,7 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^3.5.3:
+typescript@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==


### PR DESCRIPTION
* **Problem:** The `src/upload-stream.ts` example doesn't use 100% streams: `@hapi/subtext` buffers the contents of the multipart files into memory and presents them with a stream interface to the handler. This doesn't illustrate streaming very well.
* **Solution:** Use `@hapi/pez` to make the example 100% streaming.
* **Testing:** See if tests pass in CI!